### PR TITLE
feat(auth): add JWT token to API Gateway authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,6 @@ As the project is under active development, the following tasks are planned:
 
   - Implement error management, environment variable control, and monitoring.
 
-- **WebSocket Authentication and Authorization:**
-
-  - **Implement authentication and authorization** for WebSocket connections to ensure only authenticated users can access the real-time data and make predictions.
-  - **Proposed Solution:**
-    - Use [AWS API Gateway WebSocket Authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-control-access.html) to manage authentication.
-    - AWS Cognito can be used to issue and validate tokens. The token should be sent as part of the WebSocket connection request, and the authorizer should verify its validity.
-    - A step-by-step guide on how to implement this can be found [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-lambda-auth.html).
-    - Ensure that authorization rules are enforced for specific actions (e.g., making predictions, viewing score), potentially using [AWS IAM policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) for finer control.
 
 ### Frontend
 

--- a/apps/backend/src/utils/policy.ts
+++ b/apps/backend/src/utils/policy.ts
@@ -1,0 +1,40 @@
+import {
+  APIGatewayAuthorizerResult,
+  APIGatewayAuthorizerResultContext,
+} from "aws-lambda";
+
+// https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
+
+const generatePolicy = (
+  principalId: string,
+  effect: "Allow" | "Deny",
+  resource: string,
+  context?: APIGatewayAuthorizerResultContext,
+): APIGatewayAuthorizerResult => ({
+  context,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Action: "execute-api:Invoke",
+        Effect: effect,
+        Resource: resource,
+      },
+    ],
+  },
+  principalId,
+});
+
+export const generateAllowPolicy = (
+  principalId: string,
+  resource: string,
+  context?: APIGatewayAuthorizerResultContext,
+): APIGatewayAuthorizerResult =>
+  generatePolicy(principalId, "Allow", resource, context);
+
+export const generateDenyPolicy = (
+  principalId: string,
+  resource: string,
+  context?: APIGatewayAuthorizerResultContext,
+): APIGatewayAuthorizerResult =>
+  generatePolicy(principalId, "Deny", resource, context);

--- a/apps/backend/src/websockets/auth.ts
+++ b/apps/backend/src/websockets/auth.ts
@@ -1,0 +1,32 @@
+import {
+  APIGatewayAuthorizerResult,
+  APIGatewayRequestAuthorizerEvent,
+} from "aws-lambda";
+
+import { generateAllowPolicy, generateDenyPolicy } from "../utils/policy";
+import { CognitoJwtVerifier } from "aws-jwt-verify";
+
+export const cognitoJwtVerifier = CognitoJwtVerifier.create({
+  userPoolId: process.env.COGNITO_USER_POOL_ID!,
+  tokenUse: "access",
+  clientId: process.env.COGNITO_USER_POOL_CLIENT_ID!,
+});
+
+export const handler = async (
+  event: APIGatewayRequestAuthorizerEvent,
+): Promise<APIGatewayAuthorizerResult> => {
+  const token = event.queryStringParameters?.Authorization;
+
+  if (!token) {
+    return generateDenyPolicy("user", event.methodArn);
+  }
+
+  try {
+    const payload = await cognitoJwtVerifier.verify(token);
+    const userUUID = payload.sub;
+    const result = generateAllowPolicy(userUUID, event.methodArn, { userUUID });
+    return result;
+  } catch {
+    return generateDenyPolicy("user", event.methodArn);
+  }
+};

--- a/apps/backend/src/websockets/connect.ts
+++ b/apps/backend/src/websockets/connect.ts
@@ -1,10 +1,11 @@
+import { APIGatewayEvent } from "aws-lambda";
+
 import { saveConnection } from "../services/connections";
 import { createErrorResponse, createSuccessResponse } from "../utils/responses";
-import WebSocketConnectEvent from "./webSocketConnectEvent.interface";
 
-export const handler = async (event: WebSocketConnectEvent) => {
+export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
-  const userUUID = event.queryStringParameters?.userUUID;
+  const userUUID = event.requestContext.authorizer?.userUUID;
 
   if (!connectionId || !userUUID) {
     return createErrorResponse("Invalid connection ID or user UUID");

--- a/apps/backend/src/websockets/disconnect.ts
+++ b/apps/backend/src/websockets/disconnect.ts
@@ -1,8 +1,8 @@
+import { APIGatewayEvent } from "aws-lambda";
 import { deleteConnection } from "../services/connections";
 import { createErrorResponse, createSuccessResponse } from "../utils/responses";
-import WebSocketConnectEvent from "./webSocketConnectEvent.interface";
 
-export const handler = async (event: WebSocketConnectEvent) => {
+export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
   if (!connectionId) {
     return createErrorResponse("Invalid connection ID", 400);

--- a/apps/backend/src/websockets/requestLatestPrice.ts
+++ b/apps/backend/src/websockets/requestLatestPrice.ts
@@ -1,10 +1,10 @@
 import { getLatestPrice } from "../services/priceStore";
 import { sendMessage } from "../services/messaging";
 import { createUpdatePriceMessage } from "@my-org/shared";
-import WebSocketConnectEvent from "./webSocketConnectEvent.interface";
 import { createErrorResponse, createSuccessResponse } from "../utils/responses";
+import { APIGatewayEvent } from "aws-lambda";
 
-export const handler = async (event: WebSocketConnectEvent) => {
+export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
   if (!connectionId) {
     return createErrorResponse("Invalid connection ID", 400);

--- a/apps/backend/src/websockets/requestPrediction.ts
+++ b/apps/backend/src/websockets/requestPrediction.ts
@@ -6,8 +6,7 @@ import { createUpdatePredictionMessage } from "@my-org/shared";
 
 export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
-  const body = JSON.parse(event.body || "{}");
-  const userUUID = body.userUUID;
+  const userUUID = event.requestContext.authorizer?.userUUID;
 
   if (!connectionId || !userUUID) {
     return createErrorResponse("Invalid connection ID or user UUID", 400);

--- a/apps/backend/src/websockets/requestUserScore.ts
+++ b/apps/backend/src/websockets/requestUserScore.ts
@@ -6,8 +6,7 @@ import { createErrorResponse, createSuccessResponse } from "../utils/responses";
 
 export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
-  const body = JSON.parse(event.body || "{}");
-  const userUUID = body.userUUID;
+  const userUUID = event.requestContext.authorizer?.userUUID;
 
   if (!connectionId || !userUUID) {
     return createErrorResponse("Invalid connection ID or user UUID", 400);

--- a/apps/backend/src/websockets/submitPrediction.ts
+++ b/apps/backend/src/websockets/submitPrediction.ts
@@ -7,9 +7,10 @@ import { broadcastMessage } from "../services/messaging";
 
 export const handler = async (event: APIGatewayEvent) => {
   const connectionId = event.requestContext.connectionId;
-  const body = JSON.parse(event.body || "{}");
+  const userUUID = event.requestContext.authorizer?.userUUID;
 
-  const { userUUID, direction, price } = body;
+  const body = JSON.parse(event.body || "{}");
+  const { direction, price } = body;
 
   if (!connectionId || !userUUID || !direction || !price) {
     return createErrorResponse(

--- a/apps/backend/src/websockets/webSocketConnectEvent.interface.ts
+++ b/apps/backend/src/websockets/webSocketConnectEvent.interface.ts
@@ -1,9 +1,0 @@
-import { APIGatewayProxyEventV2 } from "aws-lambda";
-
-interface WebSocketConnectEvent
-  extends Omit<APIGatewayProxyEventV2, "requestContext"> {
-  requestContext: {
-    connectionId: string;
-  } & APIGatewayProxyEventV2["requestContext"];
-}
-export default WebSocketConnectEvent;

--- a/apps/frontend/src/components/Prediction/PredictionContainer.tsx
+++ b/apps/frontend/src/components/Prediction/PredictionContainer.tsx
@@ -5,19 +5,15 @@ import {
   PredictionDirection,
   createSubmitPredictionMessage,
 } from '@my-org/shared';
-import { getCurrentUser } from '@aws-amplify/auth';
 
 const PredictionContainer = () => {
   const { direction, btcPrice, sendMessage, clearPrediction } =
     useContext(WebSocketContext);
 
   const handlePrediction = async (direction: PredictionDirection) => {
-    const userId = (await getCurrentUser()).userId;
-
-    if (direction && btcPrice && userId) {
+    if (direction && btcPrice) {
       const message = createSubmitPredictionMessage({
         direction,
-        userUUID: userId,
         price: btcPrice,
       });
       sendMessage(JSON.stringify(message));

--- a/infra/lib/api-websocket/connectionHandling.ts
+++ b/infra/lib/api-websocket/connectionHandling.ts
@@ -5,9 +5,11 @@ import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as apigatewayv2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as path from 'path';
+import * as apigatewayv2Authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 export interface ConnectionHandlingProps {
+  readonly authorizer: apigatewayv2Authorizers.WebSocketLambdaAuthorizer;
   readonly webSocketApi: apigatewayv2.WebSocketApi;
   readonly removalPolicy?: cdk.RemovalPolicy;
 }
@@ -80,6 +82,7 @@ export class ConnectionHandling extends Construct {
         'ConnectIntegration',
         this.connectHandler,
       ),
+      authorizer: props.authorizer,
     });
 
     props.webSocketApi.addRoute('$disconnect', {

--- a/infra/lib/api-websocket/index.ts
+++ b/infra/lib/api-websocket/index.ts
@@ -1,15 +1,20 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ConnectionHandling } from './connectionHandling';
+import * as apigatewayv2Authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 import { Price } from './price';
 import { WebSocketApi } from './webSocketApi';
 import { Policies } from './policies';
 import { UserScore } from './userScore';
 import { Predictions } from './predictions';
 
+interface ApiWebsocketProps {
+  webSocketAuthorizer: apigatewayv2Authorizers.WebSocketLambdaAuthorizer;
+}
+
 export class ApiWebsocket extends Construct {
   webSocketApiEndpoint: string;
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props: ApiWebsocketProps) {
     super(scope, id);
 
     const webSocketApiConstruct = new WebSocketApi(this, 'WebSocketApi');
@@ -19,6 +24,7 @@ export class ApiWebsocket extends Construct {
       this,
       'ConnectionHandling',
       {
+        authorizer: props.webSocketAuthorizer,
         webSocketApi: webSocketApiConstruct.webSocketApi,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
       },

--- a/infra/lib/authentication/index.ts
+++ b/infra/lib/authentication/index.ts
@@ -1,14 +1,18 @@
 import { Construct } from 'constructs';
+import { RemovalPolicy } from 'aws-cdk-lib';
+
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as path from 'path';
-import { RemovalPolicy } from 'aws-cdk-lib';
+import * as apigatewayv2Authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 
 export class Authentication extends Construct {
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
   public readonly identityPool: cognito.CfnIdentityPool;
+  public readonly webSocketAuthorizer: apigatewayv2Authorizers.WebSocketLambdaAuthorizer;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -52,5 +56,77 @@ export class Authentication extends Construct {
         },
       ],
     });
+
+    const authenticatedRole = new iam.Role(
+      this,
+      'CognitoDefaultAuthenticatedRole',
+      {
+        assumedBy: new iam.FederatedPrincipal(
+          'cognito-identity.amazonaws.com',
+          {
+            StringEquals: {
+              'cognito-identity.amazonaws.com:aud': this.identityPool.ref,
+            },
+            'ForAnyValue:StringLike': {
+              'cognito-identity.amazonaws.com:amr': 'authenticated',
+            },
+          },
+          'sts:AssumeRoleWithWebIdentity',
+        ),
+      },
+    );
+
+    authenticatedRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cognito-sync:*'],
+        resources: ['*'],
+      }),
+    );
+
+    new cognito.CfnIdentityPoolRoleAttachment(
+      this,
+      'IdentityPoolRoleAttachment',
+      {
+        identityPoolId: this.identityPool.ref,
+        roles: {
+          authenticated: authenticatedRole.roleArn,
+        },
+      },
+    );
+
+    const websocketAuthFunction = new lambdaNodejs.NodejsFunction(
+      this,
+      'WebSocketAuthLambda',
+      {
+        runtime: lambda.Runtime.NODEJS_20_X,
+        projectRoot: path.join(__dirname, '../../../'),
+        entry: path.join(
+          __dirname,
+          '../../../apps/backend/src/websockets/auth.ts',
+        ),
+        environment: {
+          COGNITO_USER_POOL_ID: this.userPool.userPoolId,
+          COGNITO_USER_POOL_CLIENT_ID: this.userPoolClient.userPoolClientId,
+        },
+      },
+    );
+
+    websocketAuthFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cognito-idp:List*', 'cognito-idp:Describe*'],
+        resources: [this.userPool.userPoolArn],
+      }),
+    );
+
+    this.webSocketAuthorizer =
+      new apigatewayv2Authorizers.WebSocketLambdaAuthorizer(
+        'WebSocketAuthorizer',
+        websocketAuthFunction,
+        {
+          identitySource: ['route.request.querystring.Authorization'],
+        },
+      );
   }
 }

--- a/infra/lib/backend-stack.ts
+++ b/infra/lib/backend-stack.ts
@@ -7,13 +7,6 @@ export class BackendStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const apiWebsocket = new ApiWebsocket(this, 'ApiWebsocket');
-    new cdk.CfnOutput(this, 'WebSocketApiEndpoint', {
-      value: apiWebsocket.webSocketApiEndpoint,
-      description: 'The endpoint of the WebSocket API',
-      exportName: 'webSocketApiEndpoint',
-    });
-
     const auth = new Authentication(this, 'Authentication');
     new cdk.CfnOutput(this, 'UserPoolId', {
       value: auth.userPool.userPoolId,
@@ -29,6 +22,15 @@ export class BackendStack extends cdk.Stack {
       value: auth.identityPool.ref,
       description: 'The ID of the identity pool',
       exportName: 'identityPoolId',
+    });
+
+    const apiWebsocket = new ApiWebsocket(this, 'ApiWebsocket', {
+      webSocketAuthorizer: auth.webSocketAuthorizer,
+    });
+    new cdk.CfnOutput(this, 'WebSocketApiEndpoint', {
+      value: apiWebsocket.webSocketApiEndpoint,
+      description: 'The endpoint of the WebSocket API',
+      exportName: 'webSocketApiEndpoint',
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "infra"
       ],
       "dependencies": {
+        "aws-jwt-verify": "^4.0.1",
         "axios": "1.7.7"
       },
       "devDependencies": {
@@ -7234,6 +7235,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-4.0.1.tgz",
+      "integrity": "sha512-kzvi71eD3w/mCpYRUY7cz6DX4bfYihGdI2yV3FYQ2JuZZenqAqDPz0gWj0ew6vlAtdEVBNb7p+Dm2TAIxpVYMA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/aws-lambda": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "packageManager": "npm@10.8.2",
   "dependencies": {
+    "aws-jwt-verify": "^4.0.1",
     "axios": "1.7.7"
   }
 }

--- a/packages/shared/src/typeGuards.ts
+++ b/packages/shared/src/typeGuards.ts
@@ -2,7 +2,6 @@ import { PredictionDirection } from "./enums";
 import {
   UpdatePriceMessage,
   WebSocketAction,
-  UpdateLeaderboardMessage,
   WebSocketMessage,
   RequestLatestPriceMessage,
   UpdateUserScoreMessage,
@@ -17,20 +16,6 @@ export function isUpdatePriceMessage(
     message &&
     message.action === WebSocketAction.updatePrice &&
     typeof message.price === "number"
-  );
-}
-
-export function isUpdateLeaderboardMessage(
-  message: WebSocketMessage,
-): message is UpdateLeaderboardMessage {
-  return (
-    message &&
-    message.action === WebSocketAction.updateLeaderboard &&
-    Array.isArray(message.leaderboard) &&
-    message.leaderboard.every(
-      (item: { username: string; score: number }) =>
-        typeof item.username === "string" && typeof item.score === "number",
-    )
   );
 }
 

--- a/packages/shared/src/webSocketActions.ts
+++ b/packages/shared/src/webSocketActions.ts
@@ -2,7 +2,6 @@ import { PredictionDirection } from "./enums";
 
 export enum WebSocketAction {
   updatePrice = "updatePrice",
-  updateLeaderboard = "updateLeaderboard",
   requestLatestPrice = "requestLatestPrice",
   requestUserScore = "requestUserScore",
   requestPrediction = "requestPrediction",
@@ -22,18 +21,12 @@ export interface UpdatePriceMessage extends WebSocketMessageBase {
   price: number;
 }
 
-export interface UpdateLeaderboardMessage extends WebSocketMessageBase {
-  action: WebSocketAction.updateLeaderboard;
-  leaderboard: Array<{ username: string; score: number }>;
-}
-
 export interface RequestLatestPriceMessage extends WebSocketMessageBase {
   action: WebSocketAction.requestLatestPrice;
 }
 
 export interface RequestUserScoreMessage extends WebSocketMessageBase {
   action: WebSocketAction.requestUserScore;
-  userUUID: string;
 }
 
 export interface UpdateUserScoreMessage extends WebSocketMessageBase {
@@ -50,17 +43,14 @@ export interface SubmitPredictionMessage extends WebSocketMessageBase {
   action: WebSocketAction.submitPrediction;
   direction: PredictionDirection;
   price: number;
-  userUUID: string;
 }
 
 export interface RequestPredictionMessage extends WebSocketMessageBase {
   action: WebSocketAction.requestPrediction;
-  userUUID: string;
 }
 
 export type WebSocketMessage =
   | UpdatePriceMessage
-  | UpdateLeaderboardMessage
   | RequestLatestPriceMessage
   | RequestUserScoreMessage
   | UpdateUserScoreMessage
@@ -77,15 +67,6 @@ export const createUpdatePriceMessage = (
   };
 };
 
-export const createUpdateLeaderboardMessage = (
-  payload: MessagePayload<UpdateLeaderboardMessage>,
-): UpdateLeaderboardMessage => {
-  return {
-    action: WebSocketAction.updateLeaderboard,
-    ...payload,
-  };
-};
-
 export const createRequestLatestPriceMessage =
   (): RequestLatestPriceMessage => {
     return {
@@ -93,12 +74,9 @@ export const createRequestLatestPriceMessage =
     };
   };
 
-export const createRequestUserScoreMessage = (
-  payload: MessagePayload<RequestUserScoreMessage>,
-): RequestUserScoreMessage => {
+export const createRequestUserScoreMessage = (): RequestUserScoreMessage => {
   return {
     action: WebSocketAction.requestUserScore,
-    ...payload,
   };
 };
 
@@ -120,12 +98,9 @@ export const createUpdatePredictionMessage = (
   };
 };
 
-export const createRequestPredictionMessage = (
-  payload: MessagePayload<RequestPredictionMessage>,
-): RequestPredictionMessage => {
+export const createRequestPredictionMessage = (): RequestPredictionMessage => {
   return {
     action: WebSocketAction.requestPrediction,
-    ...payload,
   };
 };
 


### PR DESCRIPTION
### Add Authentication to WebSockets

This PR introduces authentication mechanisms for WebSocket connections to enhance security and ensure that only authorized users can interact with the WebSocket endpoints.

#### **Frontend**
- **JWT Token Acquisition**: Integrated Cognito to obtain the JWT token upon user authentication.
- **WebSocket Connection**: Modified the WebSocket connection logic to include the JWT token as a query parameter in the connection URL.

#### **Infrastructure (CDK)**
- **API Gateway Authorizer**: Configured an Authorizer for the `connect` endpoint in API Gateway to validate incoming WebSocket connections using the provided JWT token.

#### **Backend**
- **Token Verification Lambda**: Added a Lambda function that:
  - **Validates JWT Token**: Checks the authenticity and validity of the JWT token received from the frontend.
  - **Context Injection**: Extracts the `userUUID` from the token and injects it into the context, making it available to subsequent WebSocket endpoints.
  - **IAM Policy Generation**: Generates appropriate IAM policies based on the authenticated user's permissions, ensuring secure access control across WebSocket interactions.

These enhancements collectively ensure that WebSocket communications are secure, authenticated, and contextually aware of the user's identity and permissions.